### PR TITLE
Update vue-loader and fix renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ts-jest": "29.0.5",
     "tsconfig-paths-webpack-plugin": "4.0.0",
     "typescript": "4.9.4",
-    "vue-loader": "15.9.8",
+    "vue-loader": "15.10.1",
     "vue-template-compiler": "2.x"
   },
   "main": "dist/vue-money-amount.common.js",

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
       "matchUpdateTypes": ["major"],
       "groupName": "vue",
       "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["vue-loader", "@vue/vue-loader-v15"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "vue-loader",
+      "enabled": false
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15819,10 +15819,10 @@ vue-inbrowser-compiler-independent-utils@^4.52.0:
   resolved "https://registry.yarnpkg.com/vue-inbrowser-compiler-independent-utils/-/vue-inbrowser-compiler-independent-utils-4.54.1.tgz#2628fe92c99a06672d1b91b0f838e0272551ed02"
   integrity sha512-hQN3mzLmWM33Ua2Oua5OgF8/BJjP6+T1Wzea5xHDRYCwVvJo2pxSJLhVqluaeBe3PB5vquMddceaKC4mhLe25A==
 
-vue-loader@15.9.8:
-  version "15.9.8"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.8.tgz#4b0f602afaf66a996be1e534fb9609dc4ab10e61"
-  integrity sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==
+vue-loader@15.10.1:
+  version "15.10.1"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.10.1.tgz#c451c4cd05a911aae7b5dbbbc09fb913fb3cca18"
+  integrity sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==
   dependencies:
     "@vue/component-compiler-utils" "^3.1.0"
     hash-sum "^1.0.2"


### PR DESCRIPTION
Updates `vue-loader` and removes it from renovate's major version updates (incompatibility with storybook afterwards)